### PR TITLE
Fix bug where Select tuple of length >2 can give duplicate tuples

### DIFF
--- a/Team12/Code12/src/spa/src/pql/evaluator/EvaluatorUtils.cpp
+++ b/Team12/Code12/src/spa/src/pql/evaluator/EvaluatorUtils.cpp
@@ -8,6 +8,23 @@
 #include <unordered_map>
 #include <unordered_set>
 
+std::size_t NtupleHasher::operator()(const Vector<String>& tuple) const
+{
+    if (tuple.empty()) {
+        return 0;
+    } else {
+        std::hash<std::string> stringHasher;
+        std::size_t hashedValues = stringHasher(tuple[0]);
+        std::size_t length = tuple.size();
+        for (std::size_t i = 1; i < length; i++) {
+            const std::string& value = tuple[i];
+            hashedValues = (hashedValues
+                            ^ (stringHasher(value) + uint32_t(2654435769) + (hashedValues * 64) + (hashedValues / 4)));
+        }
+        return hashedValues;
+    }
+}
+
 PotentialValue::PotentialValue(Synonym synonym, String value): synonym(std::move(synonym)), value(std::move(value)) {}
 
 PotentialValue::PotentialValue(const SynonymWithValue& swv): synonym(swv.synonym), value(swv.value) {}

--- a/Team12/Code12/src/spa/src/pql/evaluator/EvaluatorUtils.h
+++ b/Team12/Code12/src/spa/src/pql/evaluator/EvaluatorUtils.h
@@ -20,6 +20,11 @@ typedef Vector<Pair<String, String>> PairedResult;
 
 typedef Vector<Vector<String>> NtupledResult;
 
+// A hash function for a n-tuple (Vector<String>)
+struct NtupleHasher {
+    std::size_t operator()(const Vector<String>& tuple) const;
+};
+
 // Foreward declaration of SynonymWithValue
 class SynonymWithValue;
 

--- a/Team12/Code12/src/spa/src/pql/evaluator/RelationshipsGraph.cpp
+++ b/Team12/Code12/src/spa/src/pql/evaluator/RelationshipsGraph.cpp
@@ -706,9 +706,9 @@ std::vector<PotentialValue> RelationshipsGraph::retrieveRelationships(const Pote
     }
 }
 
-NtupledResult RelationshipsGraph::retrieveRowsMatching(const Vector<Synonym>& synonyms) const
+NtupledResult RelationshipsGraph::retrieveUniqueRowsMatching(const Vector<Synonym>& synonyms) const
 {
-    NtupledResult matchingRows;
+    std::unordered_set<Vector<String>, NtupleHasher> matchingRows;
     for (const std::pair<GraphEdge, const std::unordered_set<SynonymWithValue, SynonymWithValueHasher>&> edge :
          edgesTable) {
         const std::unordered_set<SynonymWithValue, SynonymWithValueHasher>& rowValues = edge.second;
@@ -725,8 +725,8 @@ NtupledResult RelationshipsGraph::retrieveRowsMatching(const Vector<Synonym>& sy
             }
         }
         if (matchedAll) {
-            matchingRows.push_back(currentRow);
+            matchingRows.insert(currentRow);
         }
     }
-    return matchingRows;
+    return NtupledResult(matchingRows.begin(), matchingRows.end());
 }

--- a/Team12/Code12/src/spa/src/pql/evaluator/ResultsTable.cpp
+++ b/Team12/Code12/src/spa/src/pql/evaluator/ResultsTable.cpp
@@ -153,7 +153,7 @@ NtupledResult ResultsTable::joinAllSynonyms(const Vector<Synonym>& syns)
             relationships->insertRelationships(tuples, firstSyn, firstSynNewInGraph, secondSyn, secondSynNewInGraph);
         }
     }
-    return relationships->retrieveRowsMatching(syns);
+    return relationships->retrieveUniqueRowsMatching(syns);
 }
 
 std::function<void()> ResultsTable::createEvaluatorOne(ResultsTable* table, const Synonym& syn,

--- a/Team12/Code12/src/spa/src/pql/evaluator/ResultsTable.h
+++ b/Team12/Code12/src/spa/src/pql/evaluator/ResultsTable.h
@@ -559,7 +559,7 @@ public:
      * @param synonyms The synonyms to retrieve the rows of.
      * @return The result n-tuples for (syns[0], syns[1], ..., syns[n]).
      */
-    NtupledResult retrieveRowsMatching(const Vector<Synonym>& synonyms) const;
+    NtupledResult retrieveUniqueRowsMatching(const Vector<Synonym>& synonyms) const;
 };
 
 #endif // SPA_PQL_RESULTS_TABLE_H


### PR DESCRIPTION
When selecting tuples of length > 2, it will run through all the rows of the table and just take those rows that match the tuples. However, if we have a table like this:

| a | b | c | d | e |
|----|----|----|----|----|
| 1 | 1 | 1 | one | aah |
| 1 | 1 | 1 | two | bah |
| 1 | 1 | 1 | three | cah |

and we Select <a, b, c>, it will give 3x (1, 1, 1) because there are 3 edges that matched.

The solution is to use a hash set to remove the duplicates.

Have run the test script and can confirm unit, integration, system tests passing