### PR TITLE
Fix main to build on Visual Studio 2019

### DIFF
--- a/Team12/Code12/src/spa/src/frontend/parser/ErrorMessages.cpp
+++ b/Team12/Code12/src/spa/src/frontend/parser/ErrorMessages.cpp
@@ -3,6 +3,8 @@
  * The error codes correspond to the index of the message in the array.
  */
 
+#include <array>
+
 #include "Parser.h"
 
 std::array<String, maxErrorCode> errorMessages


### PR DESCRIPTION
On Visual Studio 2019, currently there is an error with uninstantiated class std::array