### PR TITLE
Parser: Add error for unexpected tokens after (...) <&& or ||> (...)

### DIFF
--- a/Team12/Code12/src/spa/src/frontend/parser/ErrorMessages.cpp
+++ b/Team12/Code12/src/spa/src/frontend/parser/ErrorMessages.cpp
@@ -40,4 +40,5 @@ std::array<String, maxErrorCode> errorMessages
        "Conditional expression parsing failed, expected conditional or relational operator after closing bracket.",
        "Conditional expression parsing failed, unrecognised expression.",
        "Conditional expression parsing failed, expected closing bracket for !( ... )",
-       "Conditional expression parsing failed, expected closing bracket for (...) opr (...)"};
+       "Conditional expression parsing failed, expected closing bracket for (...) opr (...)",
+       "Conditional expression parsing failed, unexpected token after (...) opr (...)"};

--- a/Team12/Code12/src/spa/src/frontend/parser/Parser.cpp
+++ b/Team12/Code12/src/spa/src/frontend/parser/Parser.cpp
@@ -548,8 +548,9 @@ parseConditionalExpression(frontend::TokenList* programTokens, TokenListIndex st
             // syntax error in second sub-conditional expression
             return secondCondition;
         }
-        assert(secondCondition.nextUnparsedToken // NOLINT(cppcoreguidelines-pro-bounds-array-to-pointer-decay)
-               == endIndex);
+        if (secondCondition.nextUnparsedToken != endIndex) {
+            return getSyntaxError<ConditionalExpression>(33);
+        }
         // finally, create the conditional expression
         if (programTokens->at(firstCondition.nextUnparsedToken + 1).tokenTag == frontend::AndConditionalTag) {
             return ParserReturnType<std::unique_ptr<ConditionalExpression>>(

--- a/Team12/Code12/src/spa/src/frontend/parser/Parser.h
+++ b/Team12/Code12/src/spa/src/frontend/parser/Parser.h
@@ -12,7 +12,7 @@
 
 typedef Integer TokenListIndex;
 
-const std::size_t maxErrorCode = 33;
+const std::size_t maxErrorCode = 34;
 
 // An array to map error codes to error messages
 extern std::array<String, maxErrorCode> errorMessages;


### PR DESCRIPTION
Such a program was causing the parser to crash:

```
procedure fun {
    while ((a < b) && (a < b) && (a < b)) {
        print pattern;
    }
}
```

This PR fixes that