### PR TITLE
WithUnifier: Store synonym results correctly

### DIFF
--- a/Team12/Code12/src/spa/src/pql/evaluator/attribute/WithUnifier.cpp
+++ b/Team12/Code12/src/spa/src/pql/evaluator/attribute/WithUnifier.cpp
@@ -10,18 +10,96 @@
 #include "pkb/PKB.h"
 #include "pql/evaluator/relationships/RelationshipsUtil.h"
 
-std::function<std::vector<std::string>()> createGetStatementsFunction(StatementType stmtType)
+/**
+ * Helper class to associate the default result of a
+ * synonym with the result of a certain attribute
+ */
+class WithPair {
+public:
+    String synonymResult;
+    String attributeResult;
+    WithPair(String synonym, String attribute): synonymResult(std::move(synonym)), attributeResult(std::move(attribute))
+    {}
+
+    explicit WithPair(const Pair<String, String>& synAttrPair):
+        synonymResult(synAttrPair.first), attributeResult(synAttrPair.second)
+    {}
+};
+
+/**
+ * Given raw results from the PKB, convert them into WithPairs
+ * where the attribute result is the same as the synonym result.
+ *
+ * @param numericalResults Raw results {r1, r2, ..., rn} from PKB.
+ * @return WithPairs of (rn, rn) where rn == rn and rn is a string.
+ */
+std::vector<WithPair> convertToWithPairs(const Vector<Integer>& numericalResults)
+{
+    std::vector<WithPair> pairs;
+    for (Integer res : numericalResults) {
+        std::string resStr = std::to_string(res);
+        pairs.emplace_back(resStr, resStr);
+    }
+    return pairs;
+}
+
+/**
+ * Given raw results from the PKB, convert them into WithPairs
+ * where the attribute result is the same as the synonym result.
+ *
+ * @param stringResults Raw results {r1, r2, ..., rn} from PKB.
+ * @return WithPairs of (rn, rn) where rn == rn.
+ */
+std::vector<WithPair> convertToWithPairs(const Vector<String>& stringResults)
+{
+    std::vector<WithPair> pairs;
+    for (const String& res : stringResults) {
+        pairs.emplace_back(res, res);
+    }
+    return pairs;
+}
+
+/**
+ * Given raw results from the PKB, convert them into WithPairs.
+ *
+ * @param pairedResult Raw results {(s1, r1), (s2, r2), ..., (sn, rn)} from PKB.
+ * @return WithPairs of (sn, rn) where sn is a string.
+ */
+std::vector<WithPair> convertToWithPairs(const Vector<Pair<Integer, String>>& pairedResult)
+{
+    std::vector<WithPair> pairs;
+    for (const Pair<Integer, String>& res : pairedResult) {
+        pairs.emplace_back(std::to_string(res.first), res.second);
+    }
+    return pairs;
+}
+
+/**
+ * Given raw results from the PKB, convert them into WithPairs.
+ *
+ * @param pairedResult Raw results {(s1, r1), (s2, r2), ..., (sn, rn)} from PKB.
+ * @return WithPairs of (sn, rn).
+ */
+std::vector<WithPair> convertToWithPairs(const Vector<Pair<String, String>>& pairedResult)
+{
+    std::vector<WithPair> pairs;
+    for (const Pair<String, String>& res : pairedResult) {
+        pairs.emplace_back(res);
+    }
+    return pairs;
+}
+
+std::function<std::vector<WithPair>()> createGetStatementsFunction(StatementType stmtType)
 {
     return [stmtType]() {
-        return convertToClauseResult(getAllStatements(stmtType));
+        return convertToWithPairs(getAllStatements(stmtType));
     };
 }
 
-typedef std::unordered_map<DesignEntityType,
-                           std::unordered_map<AttributeType, std::function<std::vector<std::string>()>>>
+typedef std::unordered_map<DesignEntityType, std::unordered_map<AttributeType, std::function<std::vector<WithPair>()>>>
     AttributeTypeToClosureMap;
 
-typedef std::unordered_map<DesignEntityType, std::function<std::vector<std::string>()>> SynonymTypeToClosureMap;
+typedef std::unordered_map<DesignEntityType, std::function<std::vector<WithPair>()>> SynonymTypeToClosureMap;
 
 AttributeTypeToClosureMap getAttributeTypeMap()
 {
@@ -30,26 +108,42 @@ AttributeTypeToClosureMap getAttributeTypeMap()
              {{StmtNumberType, createGetStatementsFunction(ReadStatement)},
               {VarNameType,
                []() {
-                   return getAllModifiesVariablesFromStatementType(ReadStatement);
+                   return convertToWithPairs(getAllModifiesStatementTuple(ReadStatement));
                }}}},
             {PrintType,
              {{StmtNumberType, createGetStatementsFunction(PrintStatement)},
               {VarNameType,
                []() {
-                   return getAllUsesVariablesFromStatementType(PrintStatement);
+                   return convertToWithPairs(getAllUsesStatementTuple(PrintStatement));
                }}}},
             {CallType,
-             {{StmtNumberType, createGetStatementsFunction(CallStatement)}, {ProcNameType, getAllProceduresCalled}}},
+             {{StmtNumberType, createGetStatementsFunction(CallStatement)},
+              {ProcNameType,
+               []() {
+                   // TODO: Use PKB direct method
+                   std::vector<WithPair> pairs;
+                   Vector<Integer> allCallStatements = getAllStatements(CallStatement);
+                   for (Integer call : allCallStatements) {
+                       pairs.emplace_back(std::to_string(call), getProcedureCalled(call).at(0));
+                   }
+                   return pairs;
+               }}}},
             {WhileType, {{StmtNumberType, createGetStatementsFunction(WhileStatement)}}},
             {IfType, {{StmtNumberType, createGetStatementsFunction(IfStatement)}}},
             {AssignType, {{StmtNumberType, createGetStatementsFunction(AssignmentStatement)}}},
-            {VariableType, {{VarNameType, getAllVariables}}},
+            {VariableType,
+             {{VarNameType,
+               []() {
+                   return convertToWithPairs(getAllVariables());
+               }}}},
             {ConstantType,
              {{ValueType,
                []() {
-                   return convertToClauseResult(getAllConstants());
+                   return convertToWithPairs(getAllConstants());
                }}}},
-            {ProcedureType, {{ProcNameType, getAllProcedures}}}};
+            {ProcedureType, {{ProcNameType, []() {
+                                  return convertToWithPairs(getAllProcedures());
+                              }}}}};
 }
 
 SynonymTypeToClosureMap getSynonymTypeMap()
@@ -61,12 +155,17 @@ SynonymTypeToClosureMap getSynonymTypeMap()
             {WhileType, createGetStatementsFunction(WhileStatement)},
             {IfType, createGetStatementsFunction(IfStatement)},
             {AssignType, createGetStatementsFunction(AssignmentStatement)},
-            {VariableType, getAllVariables},
+            {VariableType,
+             []() {
+                 return convertToWithPairs(getAllVariables());
+             }},
             {ConstantType,
              []() {
-                 return convertToClauseResult(getAllConstants());
+                 return convertToWithPairs(getAllConstants());
              }},
-            {ProcedureType, getAllProcedures}};
+            {ProcedureType, []() {
+                 return convertToWithPairs(getAllProcedures());
+             }}};
 }
 
 SynonymTypeToClosureMap synonymTypeMap = getSynonymTypeMap();
@@ -78,9 +177,9 @@ AttributeTypeToClosureMap attributeTypeMap = getAttributeTypeMap();
  * Knowledge Base, with the help of hash maps.
  *
  * @param ref Reference to retrieve results for.
- * @return List of results matching this reference.
+ * @return List of (syn, syn.attr) matching this reference.
  */
-Vector<String> retrieveResultsForVariableReference(const Reference& ref)
+Vector<WithPair> retrieveResultsForVariableReference(const Reference& ref)
 {
     if (ref.getReferenceType() == AttributeRefType) {
         return attributeTypeMap[ref.getDesignEntity().getType()][ref.getAttribute().getType()]();
@@ -101,7 +200,7 @@ Vector<String> retrieveResultsForVariableReference(const Reference& ref)
 Void unifyLeftKnown(const Reference& literalRef, const Reference& varRef, ResultsTable* resultsTable)
 {
     ReferenceType typeOfLiteral = literalRef.getReferenceType();
-    Vector<String> resultsForVariable = retrieveResultsForVariableReference(varRef);
+    Vector<WithPair> resultsForVariable = retrieveResultsForVariableReference(varRef);
     std::function<bool(const String&, const String&)> comparisonFunction = [](const String& str1, const String& str2) {
         return str1 == str2;
     };
@@ -112,10 +211,10 @@ Void unifyLeftKnown(const Reference& literalRef, const Reference& varRef, Result
     }
     ClauseResult matchingResults;
     String rawLiteral = literalRef.getValue();
-    for (const String& str : resultsForVariable) {
+    for (const WithPair& pair : resultsForVariable) {
         // try to find a substitution that matches
-        if (comparisonFunction(str, rawLiteral)) {
-            matchingResults.push_back(str);
+        if (comparisonFunction(pair.attributeResult, rawLiteral)) {
+            matchingResults.push_back(pair.synonymResult);
             break;
         }
     }
@@ -166,17 +265,17 @@ Void unifyBothKnown(const Reference& leftRef, const Reference& rightRef, Results
 Void unifyBothAny(const Reference& leftRef, const Reference& rightRef, ResultsTable* resultsTable)
 {
     if (leftRef == rightRef) {
-        // all subtitutions work
+        // all substitutions work
         resultsTable->storeResultsZero(true);
     }
-    Vector<String> resultsForLeft = retrieveResultsForVariableReference(leftRef);
-    Vector<String> resultsForRight = retrieveResultsForVariableReference(rightRef);
+    Vector<WithPair> resultsForLeft = retrieveResultsForVariableReference(leftRef);
+    Vector<WithPair> resultsForRight = retrieveResultsForVariableReference(rightRef);
     PairedResult matchingResults;
-    for (const String& leftRes : resultsForLeft) {
-        for (const String& rightRes : resultsForRight) {
-            // find subtitutions that work and add them to results table
-            if (leftRes == rightRes) {
-                matchingResults.emplace_back(leftRes, rightRes);
+    for (const WithPair& leftRes : resultsForLeft) {
+        for (const WithPair& rightRes : resultsForRight) {
+            // find substitutions that work and add them to results table
+            if (leftRes.attributeResult == rightRes.attributeResult) {
+                matchingResults.emplace_back(leftRes.synonymResult, rightRes.synonymResult);
                 break;
             }
         }


### PR DESCRIPTION
Fixes #63 

WithUnifier was storing the results for call.procName under the results for call in the ResultsTable, causing crashes as ResultsTable assumes call is an integer value, an also causing queries to return wrong results