### PR TITLE
Fix two bugs in With Unifier

### DIFF
--- a/Team12/Code12/src/spa/src/pql/evaluator/attribute/WithUnifier.cpp
+++ b/Team12/Code12/src/spa/src/pql/evaluator/attribute/WithUnifier.cpp
@@ -163,9 +163,11 @@ SynonymTypeToClosureMap getSynonymTypeMap()
              []() {
                  return convertToWithPairs(getAllConstants());
              }},
-            {ProcedureType, []() {
+            {ProcedureType,
+             []() {
                  return convertToWithPairs(getAllProcedures());
-             }}};
+             }},
+            {Prog_LineType, createGetStatementsFunction(AnyStatement)}};
 }
 
 SynonymTypeToClosureMap synonymTypeMap = getSynonymTypeMap();


### PR DESCRIPTION
Bug 1 - For one constant and one variable, With Unifier terminated early after finding one result

Bug 2 - Prog_Line in With Unifier crashes the program