### PR TITLE
Fix bug where ResultsTable::getResultsN returns results for empty table

### DIFF
--- a/Team12/Code12/src/spa/src/pql/evaluator/ResultsTable.cpp
+++ b/Team12/Code12/src/spa/src/pql/evaluator/ResultsTable.cpp
@@ -525,7 +525,11 @@ NtupledResult ResultsTable::getResultsN(const Vector<Synonym>& syns)
 {
     assert(syns.size() > 1); // NOLINT(cppcoreguidelines-pro-bounds-array-to-pointer-decay)
     mergeResults();
-    return joinAllSynonyms(syns);
+    if (!hasResults()) {
+        return std::vector<std::vector<String>>();
+    } else {
+        return joinAllSynonyms(syns);
+    }
 }
 
 Void ResultsTable::storeResultsZero(Boolean hasResults)


### PR DESCRIPTION
Fixes #84

ResultsTable::getResultsN was missing a "hasResults" check, which is a flag set whenever an intermediate results list returns no results when merged. Since setting the flag does not remove any data within the table, getResultsN still returned some results