### PR TITLE
Fix AffectsEvaluator ignoring other procedures for BIP

### DIFF
--- a/Team12/Code12/src/spa/src/pql/evaluator/relationships/affects/AffectsBipFacade.cpp
+++ b/Team12/Code12/src/spa/src/pql/evaluator/relationships/affects/AffectsBipFacade.cpp
@@ -8,6 +8,15 @@
 
 #include "pkb/PKB.h"
 
+Vector<String> AffectsBipFacade::getModified(Integer stmtNum)
+{
+    if (this->getType(stmtNum) == CallStatement) {
+        return Vector<String>();
+    } else {
+        return getModifiesVariablesFromStatement(stmtNum);
+    }
+}
+
 Vector<Integer> AffectsBipFacade::getNext(Integer stmtNum)
 {
     return getAllNextBipStatements(stmtNum, AnyStatement);

--- a/Team12/Code12/src/spa/src/pql/evaluator/relationships/affects/AffectsBipFacade.h
+++ b/Team12/Code12/src/spa/src/pql/evaluator/relationships/affects/AffectsBipFacade.h
@@ -19,6 +19,18 @@ public:
     AffectsBipFacade& operator=(AffectsBipFacade&&) = default;
 
     /**
+     * Returns a list of variables modified by a
+     * statement, given the statement's number, unless
+     * the statement is a Call statement.
+     *
+     * Because for the branching into procedures Affects
+     * relationship, Call statements should lead to other
+     * nodes where we can find the true source of variable
+     * modification, we ignore Calls here.
+     */
+    Vector<String> getModified(Integer stmtNum) override;
+
+    /**
      * Returns a list of statement numbers that are directly
      * after the statement number specified in the Control
      * Flow Graph with branching into other procedures,


### PR DESCRIPTION
At a Call statement, for BIP the AffectsEvaluator was still removing variables that the Call statement was modifying, even though it would go into that procedure's Control Flow Graph to determine the actual Affects relationships across procedures

This PR fixes this!