### PR TITLE
Fix literal error bug

### DIFF
--- a/Team12/Code12/src/spa/src/Util.cpp
+++ b/Team12/Code12/src/spa/src/Util.cpp
@@ -21,9 +21,14 @@ Boolean util::isPossibleConstant(const String& str)
     return isMatchingRegex(str, "\\d+");
 }
 
+Boolean util::isLiteral(const String& str)
+{
+    return str.size() > 2 && str[0] == '"' && str[str.size() - 1] == '"';
+}
+
 Boolean util::isLiteralIdent(const String& str)
 {
-    if (str.size() > 2 && str[0] == '"' && str[str.size() - 1] == '"') {
+    if (isLiteral(str)) {
         String possibleIdent = str.substr(1, str.size() - 2);
         return util::isPossibleIdentifier(possibleIdent);
     } else {

--- a/Team12/Code12/src/spa/src/Util.h
+++ b/Team12/Code12/src/spa/src/Util.h
@@ -53,6 +53,7 @@ Boolean checkVectorOfPointersEqual(const std::vector<T>& first, const std::vecto
 Boolean isPossibleIdentifier(const String& str);
 Boolean isPossibleConstant(const String& str);
 // Boolean isRelationshipReference(const String& str);
+Boolean isLiteral(const String& str);
 Boolean isLiteralIdent(const String& str);
 String removeCharFromBothEnds(String str);
 StringPair splitByFirstDelimiter(const String& str, char c);

--- a/Team12/Code12/src/spa/src/pql/evaluator/relationships/next/NextEvaluator.cpp
+++ b/Team12/Code12/src/spa/src/pql/evaluator/relationships/next/NextEvaluator.cpp
@@ -143,7 +143,7 @@ Void NextEvaluator::evaluateBothAnyStar(const Reference& leftRef, const Referenc
     for (StatementNumber stmtNum : prevTypeStatements) {
         CacheSet nextStarAnyStmtResults = getCacheNextStatement(stmtNum);
         ClauseResult filteredResults = nextStarAnyStmtResults.filterStatementType(nextRefStmtType);
-        /** Store result */
+        // Store results
         for (const String& result : filteredResults) {
             Pair<Integer, String> pairResult = std::make_pair(stmtNum, result);
             pairedResults.push_back(pairResult);

--- a/Team12/Code12/src/spa/src/pql/preprocessor/Reference.cpp
+++ b/Team12/Code12/src/spa/src/pql/preprocessor/Reference.cpp
@@ -50,7 +50,10 @@ Reference Reference::createReference(String ref, DeclarationTable& declarationTa
         return reference;
     }
 
-    if (util::isLiteralIdent(ref)) {
+    if (util::isLiteral(ref)) {
+        if (!util::isLiteralIdent(ref)) {
+            return Reference(QuerySyntaxError, "Literal is not a valid Identifier: " + ref);
+        }
         // unquote the string literal
         Reference reference(LiteralRefType, util::removeCharFromBothEnds(ref));
         return reference;


### PR DESCRIPTION
Select BOOLEAN with "1"="1" should now return Syntax error instead of Semantics