### PR TITLE
Fix Optimiser for 0 and 1 clauses

### DIFF
--- a/Team12/Code12/src/spa/src/pql/optimiser/GroupedClauses.cpp
+++ b/Team12/Code12/src/spa/src/pql/optimiser/GroupedClauses.cpp
@@ -359,8 +359,9 @@ void GroupedClauses::applyArrangementToGroup(std::queue<unsigned int> arrangemen
 
 void GroupedClauses::cleanUpEmptyGroups()
 {
-    if (listOfGroups.size() == 1)
+    if (listOfGroups.size() == 1) {
         return;
+    }
 
     auto it = listOfGroups.begin();
     while (it != listOfGroups.end()) {

--- a/Team12/Code12/src/spa/src/pql/optimiser/Optimiser.cpp
+++ b/Team12/Code12/src/spa/src/pql/optimiser/Optimiser.cpp
@@ -19,8 +19,8 @@
  */
 Void optimiseQuery(AbstractQuery& abstractQuery)
 {
-    // check if query is invalid
-    if (abstractQuery.isInvalid()) {
+    // check if query is invalid, or 1 clause and less
+    if (abstractQuery.isInvalid() || abstractQuery.getClauses().count() <= 1) {
         return;
     }
 


### PR DESCRIPTION
I remember adding this guard clause? Maybe I didn't commit


All unit/integration/system tests passing