### PR TITLE
Fix reliance of Affects BIP Evaluator on Next BIP table

### DIFF
--- a/Team12/Code12/src/spa/src/pql/evaluator/relationships/CacheTable.cpp
+++ b/Team12/Code12/src/spa/src/pql/evaluator/relationships/CacheTable.cpp
@@ -23,9 +23,10 @@ Void CacheTable::insertPartial(StatementNumber key, StatementNumber value)
 
 CacheSet CacheTable::get(StatementNumber stmtNum)
 {
-    // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-array-to-pointer-decay)
-    assert(table.find(stmtNum) != table.end());
-
+    if (table.find(stmtNum) == table.end()) {
+        // return empty set if not found
+        return CacheSet();
+    }
     return table.find(stmtNum)->second;
 }
 

--- a/Team12/Code12/src/spa/src/pql/evaluator/relationships/affects/AffectsBipEvaluator.cpp
+++ b/Team12/Code12/src/spa/src/pql/evaluator/relationships/affects/AffectsBipEvaluator.cpp
@@ -75,8 +75,8 @@ Boolean AffectsBipEvaluator::affectsBipSearch(
     }
 
     // Find all s that match AffectsBip(starting, s)
-    AffectsEvaluator::cacheModifierAssigns(startingStmtNum);
-    Vector<Integer> affectedBipStatements = AffectsEvaluator::getModifierAssigns(startingStmtNum).toVector();
+    cacheAll();
+    Vector<Integer> affectedBipStatements = getModifierAssigns(startingStmtNum).toVector();
     // Terminate when endValue is found
     Boolean foundEndValue = false;
     for (Integer affectedStatement : affectedBipStatements) {
@@ -148,6 +148,13 @@ Void AffectsBipEvaluator::cacheAllBipStar()
     bipStarCacheFullyPopulated = true;
 }
 
+Void AffectsBipEvaluator::evaluateBothKnown(Integer leftRefVal, Integer rightRefVal)
+{
+    cacheAll();
+    CacheSet resultsForLeft = getModifierAssigns(leftRefVal);
+    resultsTable.storeResultsZero(resultsForLeft.isCached(rightRefVal));
+}
+
 Void AffectsBipEvaluator::evaluateLeftKnownStar(Integer leftRefVal, const Reference& rightRef)
 {
     if (facade->getType(leftRefVal) != AssignmentStatement || !isAffectable(rightRef)) {
@@ -215,6 +222,24 @@ Void AffectsBipEvaluator::evaluateBothKnownStar(Integer leftRefVal, Integer righ
         cacheModifierBipStarTable.insertPartial(rightRefVal, leftRefVal);
     }
     resultsTable.storeResultsZero(matchedRightRef);
+}
+
+Void AffectsBipEvaluator::cacheModifierAssigns(Integer)
+{
+    // For Affects BIP, we don't use the Next BIP table as we cannot
+    // tell which exact call path the statement number belongs to.
+    //
+    // Instead we traverse the CFG BIP manually to find all results.
+    cacheAll();
+}
+
+Void AffectsBipEvaluator::cacheUserAssigns(Integer, Vector<String>)
+{
+    // For Affects BIP, we don't use the Next BIP table as we cannot
+    // tell which exact call path the statement number belongs to.
+    //
+    // Instead we traverse the CFG BIP manually to find all results.
+    cacheAll();
 }
 
 AffectsBipEvaluator::AffectsBipEvaluator(ResultsTable& resultsTable, AffectsBipFacade* facade):

--- a/Team12/Code12/src/spa/src/pql/evaluator/relationships/affects/AffectsBipEvaluator.h
+++ b/Team12/Code12/src/spa/src/pql/evaluator/relationships/affects/AffectsBipEvaluator.h
@@ -30,10 +30,30 @@ private:
     Vector<Integer> cacheModifierBipStarAssigns(Integer leftRefVal);
     Void cacheAllBipStar();
 
+    // Method for Affects
+    Void evaluateBothKnown(Integer leftRefVal, Integer rightRefVal) override;
+
+    // Methods for Affects*
     Void evaluateLeftKnownStar(Integer leftRefVal, const Reference& rightRef) override;
     Void evaluateRightKnownStar(const Reference& leftRef, Integer rightRefVal) override;
     Void evaluateBothAnyStar(const Reference& leftRef, const Reference& rightRef) override;
     Void evaluateBothKnownStar(Integer leftRefVal, Integer rightRefVal) override;
+
+    /**
+     * Runs a search over the CFG BIP to populate the cache
+     * with all assignments that affect another (modifies
+     * a variable used by another assignment), with
+     * branching into procedures considered.
+     */
+    Void cacheModifierAssigns(Integer) override;
+
+    /**
+     * Runs a search over the CFG BIP to populate the cache
+     * with all assignments that are affected (uses a
+     * variable previously modified by another assignment),
+     * with branching into procedures considered.
+     */
+    Void cacheUserAssigns(Integer, Vector<String>) override;
 
 public:
     AffectsBipEvaluator(AffectsBipEvaluator&&) = default;

--- a/Team12/Code12/src/spa/src/pql/evaluator/relationships/affects/AffectsBipFacade.cpp
+++ b/Team12/Code12/src/spa/src/pql/evaluator/relationships/affects/AffectsBipFacade.cpp
@@ -6,6 +6,8 @@
 
 #include "AffectsBipFacade.h"
 
+#include <cassert>
+
 #include "pkb/PKB.h"
 
 Vector<String> AffectsBipFacade::getModified(Integer stmtNum)

--- a/Team12/Code12/src/spa/src/pql/evaluator/relationships/affects/AffectsEvaluator.h
+++ b/Team12/Code12/src/spa/src/pql/evaluator/relationships/affects/AffectsEvaluator.h
@@ -69,24 +69,22 @@ private:
     const CfgNode* affectsSearch(const CfgNode* cfg,
                                  std::unordered_map<String, std::unordered_set<Integer>>& affectsMap,
                                  AffectsTuple& resultsLists);
-    Void cacheUserAssigns(Integer rightRefVal, Vector<String> usedFromPkb);
-    Void cacheAll();
 
     // Helper methods for Affects*
     CacheSet getCacheModifierStarStatement(StatementNumber stmtNum, StatementNumber prevStmtNum);
     CacheSet getCacheUserStarStatement(StatementNumber stmtNum, StatementNumber prevStmtNum);
-
-    // Methods for Affects
-    Void evaluateLeftKnown(Integer leftRefVal, const Reference& rightRef);
-    Void evaluateRightKnown(const Reference& leftRef, Integer rightRefVal);
-    Void evaluateBothAny(const Reference& leftRef, const Reference& rightRef);
-    Void evaluateBothKnown(Integer leftRefVal, Integer rightRefVal);
 
 protected:
     ResultsTable& resultsTable;
     // The facade which this Affects Evaluator uses to interact
     // with components outside of Query Processor (i.e. PKB)
     std::unique_ptr<AffectsEvaluatorFacade> facade;
+
+    // Methods for Affects
+    virtual Void evaluateLeftKnown(Integer leftRefVal, const Reference& rightRef);
+    virtual Void evaluateRightKnown(const Reference& leftRef, Integer rightRefVal);
+    virtual Void evaluateBothAny(const Reference& leftRef, const Reference& rightRef);
+    virtual Void evaluateBothKnown(Integer leftRefVal, Integer rightRefVal);
 
     // Methods for Affects*
     virtual Void evaluateLeftKnownStar(Integer leftRefVal, const Reference& rightRef);
@@ -95,10 +93,31 @@ protected:
     virtual Void evaluateBothKnownStar(Integer leftRefVal, Integer rightRefVal);
 
     /**
+     * Runs the Affects search through the Control Flow Graph,
+     * storing all results for Affects in the cache. If this
+     * method is called more than once, calls after the first
+     * will be ignored because the cache is already populated.
+     *
+     * In other words, this method caches all the modifiers
+     * and users in the entire SIMPLE source program. This
+     * caching is only done a maximum of 1 time per query.
+     */
+    Void cacheAll();
+
+    /**
      * Caches all the statements that the
      * given statement affects.
      */
-    Void cacheModifierAssigns(Integer leftRefVal);
+    virtual Void cacheModifierAssigns(Integer leftRefVal);
+
+    /**
+     * Caches all the statements that the
+     * given statement is affected by.
+     *
+     * @param usedFromPkb List of variables used by the assignment
+     *                    statement with number rightRefVal.
+     */
+    virtual Void cacheUserAssigns(Integer rightRefVal, Vector<String> usedFromPkb);
 
     /**
      * Gets the unique set of statements that


### PR DESCRIPTION
Fixes #163, further testing is needed to see if any regression bugs are present

* Reorder methods in AffectsEvaluator.cpp (the important changes are in AffectsBip)

All (current) unit/integration/system tests passing